### PR TITLE
fix: jinja service template

### DIFF
--- a/templates/td-agent.service.j2
+++ b/templates/td-agent.service.j2
@@ -32,7 +32,7 @@ Environment=GEM_HOME=/opt/td-agent/lib/ruby/gems/2.7.0/
 Environment=GEM_PATH=/opt/td-agent/lib/ruby/gems/2.7.0/
 ExecStart=/opt/td-agent/bin/fluentd --log $TD_AGENT_LOG_FILE $TD_AGENT_OPTIONS
 MemoryMax={{ tdagent_max_memory }}
-{%- endif -%}
+{%- endif %}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
From the documentation, adding `-%}` will clean up whitespace and newline causing this issue:
```
MemoryMax=4G[Install]
WantedBy=multi-user.target
```

ref: https://jinja.palletsprojects.com/en/3.0.x/templates
```
Minus sign at the end of {% raw -%} tag cleans all the spaces and newlines preceding the first character of your raw data.
```