### PR TITLE
feat(templates): add condition to support debian OS

### DIFF
--- a/templates/td-agent.service.j2
+++ b/templates/td-agent.service.j2
@@ -26,7 +26,7 @@ Environment=GEM_HOME=/opt/td-agent/embedded/lib/ruby/gems/2.4.0/
 Environment=GEM_PATH=/opt/td-agent/embedded/lib/ruby/gems/2.4.0/
 ExecStart=/opt/td-agent/embedded/bin/fluentd --log $TD_AGENT_LOG_FILE $TD_AGENT_OPTIONS
 MemoryLimit={{ tdagent_max_memory }}
-{% elif hostvars[inventory_hostname].ansible_distribution_major_version | int <= 20 and hostvars[inventory_hostname].ansible_distribution != 'Debian' -%}
+{% elif hostvars[inventory_hostname].ansible_distribution_major_version | int <= 20 -%}
 Environment=LD_PRELOAD=/opt/td-agent/lib/libjemalloc.so
 Environment=GEM_HOME=/opt/td-agent/lib/ruby/gems/2.7.0/
 Environment=GEM_PATH=/opt/td-agent/lib/ruby/gems/2.7.0/

--- a/templates/td-agent.service.j2
+++ b/templates/td-agent.service.j2
@@ -20,13 +20,13 @@ RuntimeDirectory=td-agent
 ExecReload=/bin/kill -HUP ${MAINPID}
 Restart=always
 TimeoutStopSec=120
-{% if hostvars[inventory_hostname].ansible_distribution_major_version | int <= 16 -%}
+{% if hostvars[inventory_hostname].ansible_distribution_major_version | int <= 16 and hostvars[inventory_hostname].ansible_distribution != 'Debian' -%}
 Environment=LD_PRELOAD=/opt/td-agent/embedded/lib/libjemalloc.so
 Environment=GEM_HOME=/opt/td-agent/embedded/lib/ruby/gems/2.4.0/
 Environment=GEM_PATH=/opt/td-agent/embedded/lib/ruby/gems/2.4.0/
 ExecStart=/opt/td-agent/embedded/bin/fluentd --log $TD_AGENT_LOG_FILE $TD_AGENT_OPTIONS
 MemoryLimit={{ tdagent_max_memory }}
-{% elif hostvars[inventory_hostname].ansible_distribution_major_version | int <= 20 -%}
+{% elif hostvars[inventory_hostname].ansible_distribution_major_version | int <= 20 and hostvars[inventory_hostname].ansible_distribution != 'Debian' -%}
 Environment=LD_PRELOAD=/opt/td-agent/lib/libjemalloc.so
 Environment=GEM_HOME=/opt/td-agent/lib/ruby/gems/2.7.0/
 Environment=GEM_PATH=/opt/td-agent/lib/ruby/gems/2.7.0/


### PR DESCRIPTION
debian gems 2.7.0
```
root@01:/opt/td-agent/lib# cd /opt/td-agent/lib/ruby/gems/
root@01:/opt/td-agent/lib/ruby/gems# ls
2.7.0
```
and related file should be under this 
```
root@01:/opt/td-agent/lib/ruby# find / -name fluentd 2>/dev/null | grep td-agent
/opt/td-agent/lib/ruby/gems/2.7.0/gems/fluentd-1.16.3/bin/fluentd
/opt/td-agent/lib/ruby/gems/2.7.0/gems/fluentd-0.14.25/bin/fluentd
/opt/td-agent/lib/ruby/gems/2.7.0/bin/fluentd
/opt/td-agent/bin/fluentd
root@01:/opt/td-agent/lib/ruby# 
```
